### PR TITLE
Replace erlang.now with os.timestamp

### DIFF
--- a/lib/bot/markov.ex
+++ b/lib/bot/markov.ex
@@ -7,7 +7,7 @@ defmodule Bot.Markov do
   end
 
   def init([client]) do
-    :random.seed(:erlang.now)
+    :random.seed(:os.timestamp)
     ExIrc.Client.add_handler client, self
     {:ok, client}
   end

--- a/lib/bot/nope.ex
+++ b/lib/bot/nope.ex
@@ -7,7 +7,7 @@ defmodule Bot.Nope do
   end
 
   def init([client]) do
-    :random.seed(:erlang.now)
+    :random.seed(:os.timestamp)
     ExIrc.Client.add_handler client, self
     {:ok, client}
   end
@@ -36,7 +36,7 @@ defmodule Bot.Nope do
     |> Enum.shuffle
     |> hd
   end
-   
+
 
 
   defp debug(msg) do

--- a/lib/bot/ohai.ex
+++ b/lib/bot/ohai.ex
@@ -7,7 +7,7 @@ defmodule Bot.Ohai do
   end
 
   def init([client]) do
-    :random.seed(:erlang.now)
+    :random.seed(:os.timestamp)
     ExIrc.Client.add_handler client, self
     {:ok, client}
   end

--- a/lib/bot/sing.ex
+++ b/lib/bot/sing.ex
@@ -7,7 +7,7 @@ defmodule Bot.Sing do
   end
 
   def init([client]) do
-    :random.seed(:erlang.now)
+    :random.seed(:os.timestamp)
     ExIrc.Client.add_handler client, self
     {:ok, client}
   end

--- a/lib/bot/soon.ex
+++ b/lib/bot/soon.ex
@@ -7,7 +7,7 @@ defmodule Bot.Soon do
   end
 
   def init([client]) do
-    :random.seed(:erlang.now)
+    :random.seed(:os.timestamp)
     ExIrc.Client.add_handler client, self
     {:ok, client}
   end
@@ -58,7 +58,7 @@ defmodule Bot.Soon do
     |> Enum.shuffle
     |> hd
   end
-   
+
 
 
   defp debug(msg) do

--- a/lib/bot/wrong.ex
+++ b/lib/bot/wrong.ex
@@ -7,7 +7,7 @@ defmodule Bot.Wrong do
   end
 
   def init([client]) do
-    :random.seed(:erlang.now)
+    :random.seed(:os.timestamp)
     ExIrc.Client.add_handler client, self
     {:ok, client}
   end
@@ -42,7 +42,7 @@ defmodule Bot.Wrong do
       _ -> "#{person}: "
     end
     message = message_prefix <> "https://pbs.twimg.com/media/B6sl-PDCUAAMFy5.jpg"
-    
+
     ExIrc.Client.msg client, :privmsg, channel, message
   end
 

--- a/lib/brain/markov.ex
+++ b/lib/brain/markov.ex
@@ -7,7 +7,7 @@ defmodule Brain.Markov do
   end
 
   def init(seed_directories) do
-    :random.seed(:erlang.now)
+    :random.seed(:os.timestamp)
     dictionary = Ngram.new
                  |> populate_with_files_in_directories(seed_directories)
     {:ok, dictionary}


### PR DESCRIPTION
:erlang.now is deprecated in Erlang 18, and so best to use :os.timestamp.
